### PR TITLE
Fix pic placeholder and placeholdername

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Adds picture to the current slide. Requires figure or axes handle or image filen
 * `Position` Four element vector: x, y, width, height (in inches) that controls the placement and size of the image. This property overrides `Scale`.
 * `LineWidth` Width of the picture's edge line, a single value (in points). Edge is not drawn by default. Unless either `LineWidth` or `EdgeColor` are specified. 
 * `EdgeColor` Color of the picture's edge, a three element vector specifying RGB value. Edge is not drawn by default. Unless either `LineWidth` or `EdgeColor` are specified. 
+* `OnClick` Links text to another slide (if slide number is given as an integer) or URL or another file
 
 ### addShape
 

--- a/exportToPPTX.m
+++ b/exportToPPTX.m
@@ -1886,28 +1886,23 @@ classdef exportToPPTX < handle
                                         retType     = exportToPPTX.getNodeAttribute(processNode,'p:ph','type');
                                         retIdx      = exportToPPTX.getNodeAttribute(processNode,'p:ph','idx');
                                         retName     = exportToPPTX.getNodeAttribute(processNode,'p:cNvPr','name');
-                                        posX        = exportToPPTX.getNodeAttribute(processNode,'a:off','x');
-                                        posY        = exportToPPTX.getNodeAttribute(processNode,'a:off','y');
-                                        posW        = exportToPPTX.getNodeAttribute(processNode,'a:ext','cx');
-                                        posH        = exportToPPTX.getNodeAttribute(processNode,'a:ext','cy');
-                                        if isempty(retType), retType = {''}; end;
-                                        if isempty(retIdx), retIdx = {''}; end;
-                                        if isempty(retName), retName = {''}; end;
-                                        if isempty(posX), posX = NaN; else posX = str2double(posX); end;
-                                        if isempty(posY), posY = NaN; else posY = str2double(posY); end;
-                                        if isempty(posW), posW = NaN;
-                                        elseif numel(posW)==2 && isempty(posW{1})
-                                            % change the posW and posH to single element instead of [NAN, posW] by Hu Jiawei.
-                                            posW = posW{2}; posW = str2double(posW);
+                                        % For position, search within a:xfrm node
+                                        xfrmNode    = exportToPPTX.findNode(processNode,'a:xfrm');
+                                        if ~isempty(xfrmNode)
+                                            posX    = exportToPPTX.getNodeAttribute(xfrmNode,'a:off','x');
+                                            posY    = exportToPPTX.getNodeAttribute(xfrmNode,'a:off','y');
+                                            posW    = exportToPPTX.getNodeAttribute(xfrmNode,'a:ext','cx');
+                                            posH    = exportToPPTX.getNodeAttribute(xfrmNode,'a:ext','cy');
                                         else
-                                            posW = str2double(posW);
+                                            posX    = []; posY = []; posW = []; posH = [];
                                         end
-                                        if isempty(posH), posH = NaN;
-                                        elseif numel(posH)==2 && isempty(posH{1})
-                                            posH = posH{2}; posH = str2double(posH);
-                                        else
-                                            posH = str2double(posH);
-                                        end
+                                        if isempty(retType), retType = {''}; end
+                                        if isempty(retIdx), retIdx = {''}; end
+                                        if isempty(retName), retName = {''}; end
+                                        if isempty(posX), posX = NaN; else, posX = str2double(posX); end
+                                        if isempty(posY), posY = NaN; else, posY = str2double(posY); end
+                                        if isempty(posW), posW = NaN; else, posW = str2double(posW); end
+                                        if isempty(posH), posH = NaN; else, posH = str2double(posH); end
                                         
                                         PPTX.SlideMaster(mCnt).Layout(ilay).ph(ielem+1)        = retType;
                                         PPTX.SlideMaster(mCnt).Layout(ilay).idx(ielem+1)       = retIdx;


### PR DESCRIPTION
1. Using 'strcmp' instead of 'strncmpi' to avoid multi-posID. If my placeholder contains 'P1' and 'P10', 'strncmpi' will give two posIDs.
2. The position of picture placeholder seems to be transformed to six vector like [1, 1, Nan, 5, Nan, 5] when using customized templates, which cause wrong position of picture. Fix this by adding an 'if' sentence.